### PR TITLE
Added merchant name to receipt

### DIFF
--- a/admin/class-paystack-forms-admin.php
+++ b/admin/class-paystack-forms-admin.php
@@ -429,6 +429,7 @@ class Kkd_Pff_Paystack_Admin
 
             // Get the location data if its already been entered
             $subject = get_post_meta($post->ID, '_subject', true);
+            $merchant = get_post_meta($post->ID, '_merchant', true);
             $heading = get_post_meta($post->ID, '_heading', true);
             $message = get_post_meta($post->ID, '_message', true);
             $sendreceipt = get_post_meta($post->ID, '_sendreceipt', true);
@@ -462,6 +463,8 @@ class Kkd_Pff_Paystack_Admin
 						</select>';
             echo '<p>Email Subject:</p>';
             echo '<input type="text" name="_subject" value="' . $subject  . '" class="widefat" />';
+            echo '<p>Merchant Name on Receipt:</p>';
+            echo '<input type="text" name="_merchant" value="' . $merchant  . '" class="widefat" />';
             echo '<p>Email Heading:</p>';
             echo '<input type="text" name="_heading" value="' . $heading  . '" class="widefat" />';
             echo '<p>Email Body/Message:</p>';
@@ -695,6 +698,7 @@ class Kkd_Pff_Paystack_Admin
             $form_meta['_redirect'] = $_POST['_redirect'];
             ///
             $form_meta['_subject'] = $_POST['_subject'];
+            $form_meta['_merchant'] = $_POST['_merchant'];
             $form_meta['_heading'] = $_POST['_heading'];
             $form_meta['_message'] = $_POST['_message'];
             $form_meta['_sendreceipt'] = $_POST['_sendreceipt'];

--- a/admin/class-paystack-forms-admin.php
+++ b/admin/class-paystack-forms-admin.php
@@ -702,6 +702,7 @@ class Kkd_Pff_Paystack_Admin
             $form_meta['_heading'] = $_POST['_heading'];
             $form_meta['_message'] = $_POST['_message'];
             $form_meta['_sendreceipt'] = $_POST['_sendreceipt'];
+            $form_meta['_sendinvoice'] = $_POST['_sendinvoice'];
             ///
             $form_meta['_recur'] = $_POST['_recur'];
             $form_meta['_recurplan'] = $_POST['_recurplan'];

--- a/public/class-paystack-forms-public-for-old-themes.php
+++ b/public/class-paystack-forms-public-for-old-themes.php
@@ -286,6 +286,7 @@ function kkd_pff_paystack_send_receipt($id, $currency, $amount, $name, $email, $
     //  echo date('F j,Y');
     $user_email = stripslashes($email);
     $subject = get_post_meta($id, '_subject', true);
+    $merchant = get_post_meta($id, '_merchant', true);
     $heading = get_post_meta($id, '_heading', true);
     $sitemessage = get_post_meta($id, '_message', true);
 
@@ -332,6 +333,7 @@ function kkd_pff_paystack_send_receipt($id, $currency, $amount, $name, $email, $
     <tr>
     <td class="column_cell font_default" align="center" valign="top" style="padding:16px;font-family:Helvetica,Arial,sans-serif;font-size:15px;text-align:center;vertical-align:top;color:#888">
     <p style="font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:23px;margin-top:16px;margin-bottom:24px">&nbsp; </p>
+    <h5 style="padding:3px 7px;font-family:Helvetica,Arial,sans-serif;font-size:10px;font-weight:bold;text-transform:uppercase;letter-spacing:2px;-webkit-border-radius:2px;border-radius:2px;white-space:nowrap;background-color:#666;color:#fff"><?php echo $merchant; ?></h5>
     <h5 style="font-family:Helvetica,Arial,sans-serif;margin-left:0;margin-right:0;margin-top:16px;margin-bottom:8px;padding:0;font-size:18px;line-height:26px;font-weight:bold;color:#383d42"><?php echo $heading; ?></h5>
     <p align="left" style="font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:23px;margin-top:16px;margin-bottom:24px">Hello <?php echo strstr($name." ", " ", true); ?>,</p>
     <p align="left" style="font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:23px;margin-top:16px;margin-bottom:24px"><?php echo $sitemessage; ?></p>

--- a/public/class-paystack-forms-public.php
+++ b/public/class-paystack-forms-public.php
@@ -2037,7 +2037,7 @@ function kkd_pff_paystack_rconfirm_payment()
         $sendreceipt = get_post_meta($payment_array->post_id, '_sendreceipt', true);
         if ($sendreceipt == 'yes') {
             $decoded = json_decode($payment_array->metadata);
-            $fullname = $decoded[0]->value;
+            $fullname = $decoded[1]->value;
             kkd_pff_paystack_send_receipt($payment_array->post_id, $currency, $amount_paid, $fullname, $payment_array->email, $paystack_ref, $payment_array->metadata);
             kkd_pff_paystack_send_receipt_owner($payment_array->post_id, $currency, $amount_paid, $fullname, $payment_array->email, $paystack_ref, $payment_array->metadata);
         }

--- a/public/class-paystack-forms-public.php
+++ b/public/class-paystack-forms-public.php
@@ -1850,7 +1850,7 @@ function kkd_pff_paystack_confirm_payment()
         $sendreceipt = get_post_meta($payment_array->post_id, '_sendreceipt', true);
         if ($sendreceipt == 'yes') {
             $decoded = json_decode($payment_array->metadata);
-            $fullname = $decoded[0]->value;
+            $fullname = $decoded[1]->value;
             kkd_pff_paystack_send_receipt($payment_array->post_id, $currency, $amount_paid, $fullname, $payment_array->email, $paystack_ref, $payment_array->metadata);
             kkd_pff_paystack_send_receipt_owner($payment_array->post_id, $currency, $amount_paid, $fullname, $payment_array->email, $paystack_ref, $payment_array->metadata);
         }

--- a/public/class-paystack-forms-public.php
+++ b/public/class-paystack-forms-public.php
@@ -341,6 +341,7 @@ function kkd_pff_paystack_send_receipt($id, $currency, $amount, $name, $email, $
     //  echo date('F j,Y');
     $user_email = stripslashes($email);
     $subject = get_post_meta($id, '_subject', true);
+    $merchant = get_post_meta($id, '_merchant', true);
     $heading = get_post_meta($id, '_heading', true);
     $sitemessage = get_post_meta($id, '_message', true);
 
@@ -387,6 +388,7 @@ function kkd_pff_paystack_send_receipt($id, $currency, $amount, $name, $email, $
     <tr>
     <td class="column_cell font_default" align="center" valign="top" style="padding:16px;font-family:Helvetica,Arial,sans-serif;font-size:15px;text-align:center;vertical-align:top;color:#888">
     <p style="font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:23px;margin-top:16px;margin-bottom:24px">&nbsp; </p>
+    <h5 style="padding:3px 7px;font-family:Helvetica,Arial,sans-serif;font-size:10px;font-weight:bold;text-transform:uppercase;letter-spacing:2px;-webkit-border-radius:2px;border-radius:2px;white-space:nowrap;background-color:#666;color:#fff"><?php echo $merchant; ?></h5>
     <h5 style="font-family:Helvetica,Arial,sans-serif;margin-left:0;margin-right:0;margin-top:16px;margin-bottom:8px;padding:0;font-size:18px;line-height:26px;font-weight:bold;color:#383d42"><?php echo $heading; ?></h5>
     <p align="left" style="font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:23px;margin-top:16px;margin-bottom:24px">Hello <?php echo strstr($name." ", " ", true); ?>,</p>
     <p align="left" style="font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:23px;margin-top:16px;margin-bottom:24px"><?php echo $sitemessage; ?></p>


### PR DESCRIPTION
Added a field on the Payment Form plugin admin page that allows you to add a name that should show on the receipt being sent to customers. 

I also fixed an issue where the option selected for "send invoice" wasn't saving